### PR TITLE
Cloneable lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## NEXT
+- Users can now clone lists
 - CKeditor no longer filters out icons
 - Reload routes after a page is saved
 

--- a/app/assets/javascripts/integral/backend.js
+++ b/app/assets/javascripts/integral/backend.js
@@ -43,6 +43,7 @@ document.addEventListener("turbolinks:load", function() {
 
   SlugGenerator.check_for_slugs();
   RecordSelector.init();
+  $('.icon-modal-trigger').leanModal();
 
   // Used for Autocomplete
   var filterSuggestions = function(suggestableInput, suggestions) {

--- a/app/assets/stylesheets/integral/modal.sass
+++ b/app/assets/stylesheets/integral/modal.sass
@@ -8,6 +8,13 @@
     padding: 12px 24px
     background-color: #2196f3
     border-top-right-radius: 2px
+    .close-btn
+      position: absolute
+      top: 15px
+      right: 20px
+      color: white
+      font-weight: bold
+      font-size: 2em
 
     h4
       color: white

--- a/app/assets/stylesheets/integral/record_selector.sass
+++ b/app/assets/stylesheets/integral/record_selector.sass
@@ -40,11 +40,4 @@
       float: left
       margin-top: 10px
       color: #7a7a7a
-  .close-btn
-    position: absolute
-    top: 15px
-    right: 20px
-    color: white
-    font-weight: bold
-    font-size: 2em
 

--- a/app/controllers/integral/backend/lists_controller.rb
+++ b/app/controllers/integral/backend/lists_controller.rb
@@ -2,8 +2,8 @@ module Integral
   module Backend
     # List controller
     class ListsController < BaseController
-      before_filter :set_list, only: [:edit, :update, :destroy, :show]
-      before_filter :authorize_with_klass, only: [ :index, :new, :create, :edit, :update, :destroy ]
+      before_filter :set_list, only: [:edit, :update, :destroy, :show, :clone]
+      before_filter :authorize_with_klass
       before_filter :set_breadcrumbs
 
       # GET /
@@ -43,6 +43,21 @@ module Integral
       # List edit form
       def edit
         add_breadcrumb I18n.t('integral.breadcrumbs.edit'), :edit_list_path
+      end
+
+      # GET /:id/clone
+      # Clone a list
+      def clone
+        title = params[:title].present? ? params[:title] : "#{@list.title} Copy"
+        title = "#{title} #{SecureRandom.hex[1..5]}"if Integral::List.find_by_title(title).present?
+
+        cloned_list = @list.dup(title)
+
+        if cloned_list.save
+          respond_successfully(I18n.t('integral.backend.lists.notification.creation_success'), backend_list_path(cloned_list))
+        else
+          respond_failure(I18n.t('integral.backend.lists.notification.creation_failure'), :show)
+        end
       end
 
       # PUT /:id

--- a/app/helpers/integral/application_helper.rb
+++ b/app/helpers/integral/application_helper.rb
@@ -2,10 +2,16 @@ module Integral
   # Base helper inherited from all Integral helpers
   module ApplicationHelper
 
+    # Combines Twitter base URL and configurable handler to output full Twitter URL
+    #
+    # @return [String] Twitter URL
     def twitter_url
       "https://www.twitter.com/#{Settings.twitter_handler}"
     end
 
+    # Combines Facebook base URL and configurable handler to output full Facebook URL
+    #
+    # @return [String] Facebook URL
     def facebook_url
       "https://www.facebook.com/#{Settings.facebook_handler}"
     end
@@ -30,6 +36,7 @@ module Integral
       snippet.html_safe
     end
 
+    # @return [String] Configurable Website title
     def site_title
       Settings.website_title
     end

--- a/app/models/integral/list.rb
+++ b/app/models/integral/list.rb
@@ -7,12 +7,32 @@ module Integral
     has_many :list_items
 
     # Validations
-    validates :title, presence: true
+    validates :title, presence: true, uniqueness: true
 
     before_destroy :validate_unlocked
 
     # Nested forms
     accepts_nested_attributes_for :list_items, reject_if: :all_blank, allow_destroy: true
+
+    # Returns stuff
+    def dup(title='')
+      new_list = super()
+      new_list.title = title if title.present?
+
+      list_items.each do |list_item|
+        new_list_item = list_item.dup
+
+        if list_item.has_children?
+          list_item.children.each do |child|
+            new_list_item.children << child.dup
+          end
+        end
+
+        new_list.list_items << new_list_item
+      end
+
+      new_list
+    end
 
     private
 

--- a/app/policies/integral/base_policy.rb
+++ b/app/policies/integral/base_policy.rb
@@ -31,5 +31,6 @@ module Integral
     alias_method :create?, :manager?
     alias_method :edit?, :manager?
     alias_method :update?, :manager?
+    alias_method :clone?, :manager?
   end
 end

--- a/app/views/integral/backend/lists/show.haml
+++ b/app/views/integral/backend/lists/show.haml
@@ -1,5 +1,7 @@
 = content_for :title, t('.title', title: @list.title)
 
+= icon_link_to 'content_copy', '#clone-modal', class: 'icon-modal-trigger right green-text tooltipped', data: { tooltip: t('integral.actions.clone') }, icon_classes: 'small'
+
 .row.lists-container
   .col.s12
     = simple_form_for [:backend, @list], data: { 'priority-enabled' => false } do |f|
@@ -30,3 +32,14 @@
 
 
 = render partial: 'integral/backend/shared/record_selector/modal', locals: { search_path: backend_img_index_path, title: 'Select an Image..', name: 'Image' }
+
+
+#clone-modal.modal
+  .modal-header
+    %i.material-icons.modal-close.close-btn close
+    %h4 Clone List
+  .modal-content
+    = form_tag clone_backend_list_path, validate: true do |f|
+      = text_field_tag :title, '', placeholder: 'New List Title'
+      = submit_tag 'Create', class: 'btn'
+

--- a/app/views/integral/backend/pages/edit.html.haml
+++ b/app/views/integral/backend/pages/edit.html.haml
@@ -1,6 +1,6 @@
 = content_for :title, t('.title', title: @page.title)
 
-= icon_link_to 'remove_red_eye', @page.path, class: 'right green-text tooltipped', data: { tooltip: t('integral.actions.view') }, icon_classes: 'small'
+= icon_link_to 'remove_red_eye', @page.path, class: 'right green-text tooltipped', data: { tooltip: t('integral.actions.clone') }, icon_classes: 'small'
 
 = render 'form'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,22 +22,23 @@ en:
 
   integral:
     actions:
-      confirm: 'Are you sure?'
-      create: 'Create'
-      save: 'Save'
-      delete: 'Delete'
-      edit: 'Edit'
-      update: 'Update'
-      send: 'Send'
-      view: 'View'
-      read_more: 'Read more..'
-      reply: 'Reply'
+      confirm: Are you sure?
+      create: Create
+      clone: Clone
+      save: Save
+      delete: Delete
+      edit: Edit
+      update: Update
+      send: Send
+      view: View
+      read_more: Read more..
+      reply: Reply
     prompts:
-      select_image: 'Select Image..'
-      select_type: 'Select Type..'
+      select_image: Select Image..
+      select_type: Select Type..
     placeholders:
-      description: 'Description'
-      title: 'Title'
+      description: Description
+      title: Title
 
     breadcrumbs:
       home: 'Home'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,6 +24,7 @@ ja:
     actions:
       confirm: 'これでよろしいですか？'
       create: '作成'
+      clone: JA Clone
       save: '保存'
       delete: '削除'
       edit: '編集'

--- a/lib/integral/router.rb
+++ b/lib/integral/router.rb
@@ -67,7 +67,11 @@ module Integral
           end
 
           # List Management
-          resources :lists
+          resources :lists do
+            member do
+              post 'clone'
+            end
+          end
 
           # Settings Management
           resources :settings, only: [:index, :create]

--- a/lib/integral/swiper_list_renderer.rb
+++ b/lib/integral/swiper_list_renderer.rb
@@ -1,6 +1,7 @@
 module Integral
   # Swiper list renderer - Renders list items within swiper container
   class SwiperListRenderer < Integral::ListRenderer
+    # Override Integral::ListRenderer#render to wrap swiper-container around all rendered_items
     def render
       rendered_items = ''
       list_items = list.list_items.to_a

--- a/lib/integral/version.rb
+++ b/lib/integral/version.rb
@@ -1,3 +1,4 @@
+# :nocov:
 module Integral
   # Integral Version
   VERSION = "0.1.3"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -82,7 +82,7 @@ FactoryGirl.define do
     ip_address { Faker::Internet.ip_v4_address }
   end
 
-  factory :integral_list_item_basic, class: 'Integral::Basic' do
+  factory :integral_list_item_basic, class: 'Integral::Basic', aliases: [:integral_list_item] do
     title
   end
 

--- a/spec/models/integral/list_spec.rb
+++ b/spec/models/integral/list_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+module Integral
+  describe List do
+    let(:list) { build(:integral_list) }
+
+    subject { list }
+
+    it 'has a valid factory' do
+      expect(list.valid?).to be true
+    end
+
+    describe 'relations' do
+      it { is_expected.to have_many :list_items }
+    end
+
+    describe 'validates' do
+      it { is_expected.to validate_presence_of :title }
+      it { is_expected.to validate_uniqueness_of :title }
+    end
+
+    describe '#validate_unlocked' do
+      context 'when locked' do
+        it "can't be deleted" do
+          list.locked = true
+          list.destroy
+
+          expect(list.destroy).to be_falsy
+        end
+      end
+
+      context 'when not locked' do
+        it "can be deleted" do
+          list.destroy
+
+          expect(list.destroy).to be_truthy
+        end
+      end
+    end
+
+    describe '#dup' do
+      let(:list_item) { create(:integral_list_item) }
+      let(:list_item_with_child) { create(:integral_list_item, children: [list_item]) }
+      let(:list) { create(:integral_list, list_items: [list_item]) }
+      let(:list_with_child) { create(:integral_list, list_items: [list_item_with_child]) }
+
+      it 'returns expected list attributes' do
+        clone = list.dup
+
+        expect(clone.title).to eq list.title
+        expect(clone.description).to eq list.description
+      end
+
+      it 'returns expected list items' do
+        clone = list_with_child.dup
+
+        expect(clone.list_items.size).to eq list_with_child.list_items.size
+        list_with_child.list_items.each do |list_item|
+          cloned_item = clone.list_items.find{ |li| li.priority == list_item.priority }
+          expect(cloned_item.title).to eq list_item.title
+          expect(cloned_item.children.size).to eq list_item.children.size
+
+          list_item.children.each do |child|
+            cloned_child = cloned_item.children.find{ |li| li.priority == child.priority }
+
+            expect(cloned_child.title).to eq child.title
+          end
+        end
+      end
+
+      context 'when title is provided' do
+        let(:new_title) { 'Some awesome title' }
+        it 'returns expect list with provided title' do
+          clone = list.dup(new_title)
+
+          expect(clone.title).to eq new_title
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows users to clone lists by clicking the copy icon on the edit screen.

TODO: 

- [ ] Add integration and controller specs
- [ ] May want to add clone option on the listing page