### PR TITLE
Images - Add images versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 ## NEXT
+- Add Image versions - Thumbnail, Small, Medium, Large. The sizes are configurable.
+- Add Swiper next and previous buttons to SwiperListRenderer
+- Enable compression and static cache control by default (added `compress_enabled` config variable to disable)
+- Process Post image uploads in the background
 - Fix 'A copy of ApplicationController has been removed' error which was occurring in development mode.
 - Fix accidentally resizing non editor images to editor size limit
 - Fix Asset Precompile no longer crashes out when no database is available
-- Process Post image uploads in the background
 - Lock Parsley to ~> 2.4.4 due to breaking change in 2.7.0
-- Add Swiper next and previous buttons to SwiperListRenderer
-- Enable compression and static cache control by default (added `compress_enabled` config variable to disable)
 
 ### Breaking Changes
 - ```frontend_parent_controller``` config variable now expects a string rather than a Class
+- Should `display: none` on swiper next and previous buttons if they are not required
+- All existing images need there versions created.
+```
+Integral::Image.find_each do |image|
+  image.file.recreate_versions!
+end
+```
 
 ## 0.1.5 (March 29, 2017)
 - Unsaved changes check now occurs for turbolinks visits and has been added on post and list edit pages

--- a/app/models/integral/user.rb
+++ b/app/models/integral/user.rb
@@ -36,6 +36,11 @@ module Integral
       ]
     end
 
+    # @return [String] return the avatar filename
+    def avatar_filename
+      name
+    end
+
     private
 
     def send_devise_notification(notification, *args)

--- a/app/uploaders/integral/avatar_uploader.rb
+++ b/app/uploaders/integral/avatar_uploader.rb
@@ -5,15 +5,5 @@ module Integral
     def default_url
       ActionController::Base.helpers.asset_path("integral/defaults/user_avatar.jpg")
     end
-
-    # Create different versions of your uploaded files
-    version :thumb do
-      process :resize_to_fit => [50, 50]
-    end
-
-    # Override the filename of the uploaded files
-    def filename
-      model.name.parameterize if original_filename
-    end
   end
 end

--- a/app/uploaders/integral/image_uploader.rb
+++ b/app/uploaders/integral/image_uploader.rb
@@ -20,7 +20,28 @@ module Integral
 
     # Override the filename of the uploaded files
     def filename
-      "#{model.title.parameterize}.#{file.extension}" if original_filename
+      return unless original_filename
+
+      if model.respond_to?("#{mounted_as}_filename")
+        filename = model.send("#{mounted_as}_filename")
+      else
+        filename = model.title.parameterize
+      end
+
+      "#{filename}.#{file.extension}"
+    end
+
+    # Return original URL if procesing hasn't been complete (no versions available)
+    def url *args
+      version_name, _ = args
+
+      if model.send("#{mounted_as}_processing?".to_sym)
+        # Without Args
+        super()
+      else
+        # With Args
+        super
+      end
     end
 
     # Override full_filename to set version name at the end
@@ -63,7 +84,7 @@ module Integral
 
     # Thumbnail Version
     version :thumbnail, from_version: :small do
-      process :resize_to_fit => Integral.configuration.image_thumbnail_size
+      process :resize_to_fill => Integral.configuration.image_thumbnail_size
     end
   end
 end

--- a/app/uploaders/integral/post_image_uploader.rb
+++ b/app/uploaders/integral/post_image_uploader.rb
@@ -3,7 +3,7 @@ module Integral
   class PostImageUploader < ImageUploader
     include CarrierWave::MiniMagick
 
-    # Provide a default URL as a default if there hasn't been a file uploaded
+    # Provide a fallback URL if there hasn't been a file uploaded
     def default_url
       ActionController::Base.helpers.asset_path("integral/defaults/post_image.jpg")
     end

--- a/app/views/integral/backend/images/_card.html.haml
+++ b/app/views/integral/backend/images/_card.html.haml
@@ -4,7 +4,7 @@
   .integral-card
     = link_to edit_backend_img_path(image) do
       .card-image
-        = image_tag image.file
+        = image_tag image.file.url(:small)
         %span.card-title= image.title
     .card-action
       = link_to 'Edit', edit_backend_img_path(image)

--- a/app/views/integral/backend/images/index.html.haml
+++ b/app/views/integral/backend/images/index.html.haml
@@ -1,6 +1,6 @@
 = content_for :title, t('.title')
 
-= link_to t('.new_image'), '#new_image_modal', class: 'waves-effect waves-light btn modal-trigger-new-image' 
+= link_to t('.new_image'), '#new_image_modal', class: 'waves-effect waves-light btn modal-trigger-new-image'
 
 -if @images.present?
   #image-container.row
@@ -8,6 +8,6 @@
       = render partial: 'card', locals: { image: image }
 - else
   .card-panel.center
-    %p= t('.no_images_available') 
+    %p= t('.no_images_available')
 
 = render 'create_modal'

--- a/app/views/layouts/integral/backend/_header.haml
+++ b/app/views/layouts/integral/backend/_header.haml
@@ -8,10 +8,9 @@
       %ul.side-nav#admin-menu
         %li#user-menu
           #user-menu-contents
-            = image_tag(current_user.avatar)
+            = image_tag(current_user.avatar.url(:thumbnail))
             %span= t('integral.navigation.signed_in_as')
-            %span#user-menu-name
-              = current_user.name
+            %span#user-menu-name= current_user.name
         %div
           = render 'layouts/integral/backend/side_nav_list_items'
         #admin-menu-footer

--- a/db/migrate/20170425091312_add_image_processing_fields.rb
+++ b/db/migrate/20170425091312_add_image_processing_fields.rb
@@ -1,0 +1,7 @@
+class AddImageProcessingFields < ActiveRecord::Migration
+  def change
+    add_column :integral_images, :file_processing, :boolean, null: false, default: true
+    add_column :integral_users, :avatar_processing, :boolean, null: false, default: true
+    add_column :integral_posts, :image_processing, :boolean, null: false, default: true
+  end
+end

--- a/integral.gemspec
+++ b/integral.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency "will_paginate-foundation", "~> 6.2" # Pagination for Foundation
   s.add_dependency "font-awesome-sass", '~> 4.3' # Grid Icons
   s.add_dependency "breadcrumbs_on_rails", "~> 3.0" # Breadcrumbs
-  s.add_dependency "carrierwave", "~> 0.11" # File uploader
+  s.add_dependency "carrierwave", "~> 0.11" # File uploader - Careful when upgrading. Make sure overrides still work in Integral::ImageUploader
   s.add_dependency "carrierwave-imageoptimizer", "~> 1.4" # Image compression
   s.add_dependency "carrierwave_backgrounder" #, "~> 1.4" # Delayed image processing
   s.add_dependency "ckeditor", "= 4.2.0" # WYSIWYG Editor

--- a/lib/integral/configuration.rb
+++ b/lib/integral/configuration.rb
@@ -12,6 +12,10 @@ module Integral
                   :facebook_app_id,
                   :twitter_handler,
                   :editor_image_size_limit,
+                  :image_thumbnail_size,
+                  :image_small_size,
+                  :image_medium_size,
+                  :image_large_size,
                   :image_compression_quality,
                   :additional_page_templates,
                   :compression_enabled
@@ -36,8 +40,13 @@ module Integral
       ]
 
       @frontend_parent_controller = "Integral::ApplicationController"
+
       @editor_image_size_limit = [800, 800]
       @image_compression_quality = 90
+      @image_thumbnail_size = [50, 50]
+      @image_small_size = [320, 320]
+      @image_medium_size = [640, 640]
+      @image_large_size = [1280, 1280]
       @additional_page_templates = []
       @compression_enabled = true
     end

--- a/lib/integral/page_router.rb
+++ b/lib/integral/page_router.rb
@@ -26,20 +26,22 @@ module Integral
 
     private
 
+    # Checks if dynamic page routing should be enabled
+    # If there is any issue connecting to the database or if integral_pages table does not exist we return false
     def self.database_is_ready?
       table_exists = ActiveRecord::Base.connection.table_exists?('integral_pages') ? true : false
-      # Enable 'DISABLE_ROUTER' when carrying out modifications on the Users table
+      # TODO: Change this to configuration variable
       disable_router = ENV['DISABLE_ROUTER']
 
       if table_exists && disable_router != 'true'
-        Rails.logger.info "Dynamic Page Router Enabled"
+        Rails.logger.info "Integral: Dynamic Page Router Enabled"
         true
       else
-      Rails.logger.info "Integral Dynamic Page Routing Disabled"
+        Rails.logger.info "Integral: Dynamic Page Routing Disabled"
         false
       end
-    rescue
-      Rails.logger.info "Integral Dynamic Page Routing Disabled"
+    rescue => error
+      Rails.logger.info "Integral: Dynamic Page Routing Disabled [Error connecting to DB]"
       false
     end
   end


### PR DESCRIPTION
Automatically create the follow images versions (in the background) when an image is uploaded;
- Thumbnail
- Small
- Medium
- Large

The sizes are configurable. The image falls back to original if the versions have not yet been created. Possible improvement to this is to make the versions conditional (for instance very unlikely to use medium or large avatars).
