### PR TITLE
Add config initializer generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 - Add Image versions - Thumbnail, Small, Medium, Large. The sizes are configurable.
 - Add Swiper next and previous buttons to SwiperListRenderer
+- Add config initializer generator `rails generate integral:install`
 - Enable compression and static cache control by default (added `compress_enabled` config variable to disable)
 - Process Post image uploads in the background
 - Upgrade carrierwave to 1.1.0 - Includes performance enhancemente. Note: carrierwave_backgrounder should be >=0.4.3

--- a/README.md
+++ b/README.md
@@ -51,11 +51,20 @@ And then execute:
   # db/seeds.rb
   Integral::Engine.load_seed
  ```
-4. Setup database - Copy and run necessary migrations
+4. The currently released version of carrierwave_backgrounder is nearly 2 years old. Hopefully a new version will be released soon, until then we have to point to master (or a fork). Add the following to your Gemfile:
+```
+  # Remove this when new gem version is released (< 0.4.2)
+  gem 'carrierwave_backgrounder', git: 'git://github.com/lardawge/carrierwave_backgrounder.git'
+```
+5. Setup database - Copy and run necessary migrations
 ```
   rake integral:install:migrations
   rake db:migrate
   rake db:setup
+```
+6. Add configuration initializer
+```
+rails generate integral:install
 ```
 
 ## Heroku Setup

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ And then execute:
 ```
 rails generate integral:install
 ```
-7. Install your preferred background task manager. If this is not Delayed Job you'll have to update the `carrierwave_backgrounder` config file
+7. Install your preferred background task manager. If this is not [Delayed Job][delayed-job] you'll have to update the `carrierwave_backgrounder` config file
 ```
 config/initializers/carrierwave_backgrounder.rb
 ```
@@ -147,3 +147,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 [letter-opener]: https://github.com/ryanb/letter_opener
 [rails-12-factor]: https://devcenter.heroku.com/articles/getting-started-with-rails4#heroku-gems
 [ckeditor]: https://github.com/galetahub/ckeditor
+[delayed-job]: https://github.com/collectiveidea/delayed_job

--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ And then execute:
   rake db:migrate
   rake db:setup
 ```
-6. Add configuration initializer
+6. Run Integral install rake task (adds configuration initializers)
 ```
 rails generate integral:install
+```
+7. Install your preferred background task manager. If this is not Delayed Job you'll have to update the `carrierwave_backgrounder` config file
+```
+config/initializers/carrierwave_backgrounder.rb
 ```
 
 ## Heroku Setup

--- a/config/initializers/carrierwave_backgrounder.rb
+++ b/config/initializers/carrierwave_backgrounder.rb
@@ -1,3 +1,0 @@
-CarrierWave::Backgrounder.configure do |c|
-  c.backend :delayed_job, queue: :carrierwave
-end

--- a/lib/generators/integral/install_generator.rb
+++ b/lib/generators/integral/install_generator.rb
@@ -1,0 +1,12 @@
+module Integral
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path("../../templates", __FILE__)
+      desc "Creates Integral, Carrierwave & CarrierwaveBackgrounder initializers"
+
+      def copy_initializer_file
+        copy_file "integral.rb", "config/initializers/integral.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/integral/install_generator.rb
+++ b/lib/generators/integral/install_generator.rb
@@ -6,6 +6,8 @@ module Integral
 
       def copy_initializer_file
         copy_file "integral.rb", "config/initializers/integral.rb"
+        copy_file "carrierwave.rb", "config/initializers/carrierwave.rb"
+        copy_file "carrierwave_backgrounder.rb", "config/initializers/carrierwave_backgrounder.rb"
       end
     end
   end

--- a/lib/generators/templates/carrierwave.rb
+++ b/lib/generators/templates/carrierwave.rb
@@ -1,0 +1,32 @@
+CarrierWave.configure do |config|
+  # Use AWS storage when in production, otherwise use file
+  config.storage = Rails.env.production? ? :aws : :file
+
+  # Disable processing when testing
+  config.enable_processing = !Rails.env.test?
+
+  # Below configuration is used for Production only. This assumes you are using AWS for file storage in production (Recommended)
+  # Commment this line out and edit #3 when testing AWS locally
+  break unless Rails.env.production?
+
+  # The maximum period for authenticated_urls is only 7 days.
+  config.aws_authenticated_url_expiration = 60 * 60 * 24 * 7
+
+  # Set custom options such as cache control to leverage browser caching
+  config.aws_attributes = {
+    expires: 1.week.from_now.httpdate,
+    cache_control: 'max-age=604800'
+  }
+
+  # AWS Configuration
+  config.aws_bucket = ENV.fetch('S3_BUCKET_NAME')
+  config.aws_acl    = 'public-read'
+  config.aws_credentials = {
+    access_key_id:     ENV.fetch('AWS_ACCESS_KEY_ID'),
+    secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
+    region:            ENV.fetch('AWS_REGION') # Required
+  }
+
+  # CDN configuration (Recommended)
+  # config.asset_host = 'https://cdn.example.com'
+end

--- a/lib/generators/templates/carrierwave_backgrounder.rb
+++ b/lib/generators/templates/carrierwave_backgrounder.rb
@@ -1,0 +1,10 @@
+CarrierWave::Backgrounder.configure do |c|
+  c.backend :delayed_job, queue: :carrierwave
+  # c.backend :active_job, queue: :carrierwave
+  # c.backend :resque, queue: :carrierwave
+  # c.backend :sidekiq, queue: :carrierwave
+  # c.backend :girl_friday, queue: :carrierwave
+  # c.backend :sucker_punch, queue: :carrierwave
+  # c.backend :qu, queue: :carrierwave
+  # c.backend :qc
+end

--- a/lib/generators/templates/integral.rb
+++ b/lib/generators/templates/integral.rb
@@ -1,0 +1,43 @@
+Integral.configure do |config|
+  # Configure the parent controller which the blog and dynamic pages controller inherits from. Default is 'Integral::ApplicationController'
+  # config.frontend_parent_controller = "::ApplicationController"
+
+  # Configure the backend namespace. Default is 'admin'
+  # config.backend_namespace = 'dashboard'
+
+  # Configure the blog namespace. Default is 'blog'
+  # config.backend_namespace = 'news'
+
+  # Configure whether or not the blog is enabled. Default is true
+  # config.blog_enabled = false
+
+  # Manage what page templates the user has to choose from (apart from the default) when creating a page. Default is []
+  # config.additional_page_templates = [:full_width]
+
+  # Configure what page paths are protected from user entry to prevent accidentally overriding
+  # config.black_listed_paths = [
+  #   '/admin/',
+  #   '/blog/'
+  # ]
+
+  # Configure whether or not HTML (JS, Gzip, minification, etc) compression is enabled in production. Default is true
+  # config.compression_enabled = false
+
+  # Configure the maximum dimensions of images uploaded through CKeditor
+  # config.editor_image_size_limit = [800, 800]
+
+  # Configure image compression quality. 100 for lossless. Default is 90
+  # config.image_compression_quality = 100
+
+  # Configure the maximum dimensions of an image thumbnail version. Default is [50, 50]
+  # config.image_thumbnail_size = [100, 100]
+
+  # Configure the maximum dimensions of an image small version. Default is [320, 320]
+  # config.image_thumbnail_size = [500, 500]
+
+  # Configure the maximum dimensions of an image medium version. Default is [640, 640]
+  # config.image_thumbnail_size = [800, 800]
+
+  # Configure the maximum dimensions of an image large version. Default is [1280, 1280]
+  # config.image_thumbnail_size = [1600, 1600]
+end


### PR DESCRIPTION
This generator adds 3 configuration files to the host application:

- `config/initializers/integral.rb`
- `config/initializers/carrierwave.rb`
- `config/initializers/carrierwave_backgrounder.rb`

This resolves #22. The carrierwave_backgrounder manager is now configurable. Default is set to `DelayedJob`. 